### PR TITLE
Change internal string to UTF8 format

### DIFF
--- a/CommandLine.cpp
+++ b/CommandLine.cpp
@@ -28,37 +28,37 @@ CArrayEx<sLine*, sLine*> aCommand;
 
 //Commands.
 sLine CLine[] = {
-	{"-c0",0},
-	{"-c1",0},
-	{"-c2",0},
-	{"-e0",0},
-	{"-e1",0},
-	{"-e2",0},
-	{"-title",0},
-	{"-mpq",0},
-	{"-profile", 0},
-	{"-handle", 0},
-	{"-multi", 0},
-	{"-sleepy", 0},
-	{"-cachefix",0}
+	{L"-c0",0},
+	{L"-c1",0},
+	{L"-c2",0},
+	{L"-e0",0},
+	{L"-e1",0},
+	{L"-e2",0},
+	{L"-title",0},
+	{L"-mpq",0},
+	{L"-profile", 0},
+	{L"-handle", 0},
+	{L"-multi", 0},
+	{L"-sleepy", 0},
+	{L"-cachefix",0}
 };
 
-DWORD ParseStringForText(LPSTR Source,LPSTR text)
+DWORD ParseStringForText(LPWSTR Source,LPWSTR text)
 {
-	CHAR BUF[4059];
+	WCHAR BUF[4059];
 	memset(BUF,0x00,4059);
 
-	for(unsigned int x = 0; x < strlen(Source); x++)
+	for(unsigned int x = 0; x < wcslen(Source); x++)
 	{
-		if(strlen(text) + x > strlen(Source))
+		if(wcslen(text) + x > wcslen(Source))
 			break;
 
-		for(unsigned int y = 0; y < strlen(text); y++)
+		for(unsigned int y = 0; y < wcslen(text); y++)
 		{
 			INT cC = Source[x+y];
-			memcpy(BUF+strlen(BUF),(LPSTR)&cC,sizeof(cC));
+			memcpy(BUF+wcslen(BUF),(LPWSTR)&cC,sizeof(cC));
 		}
-		if(!_strcmpi(BUF,text))
+		if(!_wcsicmp(BUF,text))
 			return x;
 
 		memset(BUF,0x00,4059);
@@ -67,7 +67,7 @@ DWORD ParseStringForText(LPSTR Source,LPSTR text)
 }
 
 
-VOID ParseCommandLine(LPSTR Command)
+VOID ParseCommandLine(LPWSTR Command)
 {
 	for(int x = 0; x < ArraySize(CLine); x++)
 	{
@@ -75,16 +75,16 @@ VOID ParseCommandLine(LPSTR Command)
 		if(id == -1)
 			continue;
 
-		CHAR szText[100];
+		WCHAR szText[200];
 		BOOL bStart = false;
 
 		memset(szText,0x00,100);
 
 		if(!CLine[x].isBool)
 		{
-			for(unsigned int y = (id+(strlen(CLine[x].Param))); y < strlen(Command); y++)
+			for(unsigned int y = (id+(wcslen(CLine[x].Param))); y < wcslen(Command); y++)
 			{
-				if(Command[y] == '"')
+				if(Command[y] == L'"')
 					if(bStart){
 						bStart = false;
 						break;
@@ -97,23 +97,23 @@ VOID ParseCommandLine(LPSTR Command)
 					int byt = Command[y];
 
 				if(bStart)
-					memcpy(szText+strlen(szText),(LPSTR)&byt,sizeof(byt));
+					memcpy(szText+wcslen(szText),(LPWSTR)&byt,sizeof(byt));
 			}
 		}
 		sLine *sl = new sLine;
 		sl->isBool = CLine[x].isBool;
-		strcpy_s(sl->Param,sizeof(sl->Param),CLine[x].Param);
+		wcscpy_s(sl->Param,sizeof(sl->Param),CLine[x].Param);
 		if(!sl->isBool)
-			strcpy_s(sl->szText,sizeof(sl->szText),szText);
+			wcscpy_s(sl->szText,sizeof(sl->szText),szText);
 
 		aCommand.Add(sl);
 	}
 }
 
-sLine *GetCommand(LPSTR Param)
+sLine *GetCommand(LPWSTR Param)
 {
 	for(int x = 0; x < aCommand.GetSize(); x++)
-		if(!_strcmpi(aCommand[x]->Param,Param))
+		if(!_wcsicmp(aCommand[x]->Param,Param))
 			return aCommand[x];
 
 	return 0;

--- a/CommandLine.h
+++ b/CommandLine.h
@@ -21,13 +21,13 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 
 struct sLine{
-	CHAR Param[200];
+	WCHAR Param[400];
 	BOOL isBool;
-	CHAR szText[300];
+	WCHAR szText[600];
 };
 
-void ParseCommandLine(LPSTR Command);
-sLine *GetCommand(LPSTR Param);
+void ParseCommandLine(LPWSTR Command);
+sLine *GetCommand(LPWSTR Param);
 
 extern CArrayEx<sLine*, sLine*> aCommand;
 

--- a/Core.cpp
+++ b/Core.cpp
@@ -18,26 +18,30 @@ bool SplitLines(const std::string & str, size_t maxlen, const char delim, std::l
 	if(str.length() < 1 || maxlen < 2)
 		return false;
 
-	size_t pos, len;
+	size_t pos;
 	string tmp(str);
 
-	while(tmp.length() > maxlen)
+	// Try getting appropriate maxlength for UTF8 string
+	double ratio = (double)tmp.size() / UTF8Length(tmp);
+	int maxLength = (int)((int)maxlen - ((ratio - 1.0) * 20));
+
+	while(UTF8Length(tmp) > maxLength)
 	{
-		len = tmp.length();
-		// maxlen-1 since std::string::npos indexes from 0
-		pos = tmp.find_last_of(delim, maxlen-1);
+		// Get byte index for UTF8 string
+		int byteIdx = UTF8FindByteIndex(tmp, maxLength);
+		// byteIdx-1 since std::string::npos indexes from 0
+		pos = tmp.find_last_of(delim, byteIdx-1);
 		if(!pos || pos == string::npos)
 		{
-			//Target delimiter was not found, breaking at maxlen
-			// maxlen-1 since std::string::npos indexes from 0
-			lst.push_back(tmp.substr(0, maxlen-1));
-			tmp.erase(0, maxlen-1);
+			//Target delimiter was not found, breaking at byteIdx
+			lst.push_back(tmp.substr(0, byteIdx));
+			tmp.erase(0, byteIdx);
 			continue;
 		}
-		pos = tmp.find_last_of(delim, maxlen-1);
+		pos = tmp.find_last_of(delim, byteIdx-1);
 		if(pos && pos != string::npos)
 		{
-			//We found the last delimiter before maxlen
+			//We found the last delimiter before byteIdx
 			lst.push_back(tmp.substr(0, pos) + delim);
 			tmp.erase(0, pos);
 		}
@@ -162,7 +166,7 @@ void __fastcall Say(const char *szMessage)
 		delete aMsg;
 		aMsg = NULL;
 
-		//Print("ÿc2D2BSÿc0 :: say() in game has been disabled for now, due to crashes");
+		//Print("Ã¿c2D2BSÃ¿c0 :: say() in game has been disabled for now, due to crashes");
 /*
 		Vars.bDontCatchNextMsg = FALSE;
 		int len = 6+strlen(szMessage);
@@ -240,4 +244,31 @@ void LoadMPQ(const char* mpq)
 	D2WIN_InitMPQ(mpq, 0, 0, 3000);
 	*p_BNCLIENT_XPacKey = *p_BNCLIENT_ClassicKey = *p_BNCLIENT_KeyOwner = NULL;
 	//BNCLIENT_DecodeAndLoadKeys();
+}
+
+int UTF8FindByteIndex(std::string str, int maxutf8len)
+{
+	int utf8len = 0, byteIndex = 0;
+	const char* tstr = str.c_str();
+	size_t strlen = str.size();
+
+	for (byteIndex=0; byteIndex < strlen; byteIndex++)
+	{
+		if ((tstr[byteIndex] & 0xc0) != 0x80)
+			utf8len += 1;
+
+		if (utf8len >= maxutf8len)
+			break;
+	}
+
+	return byteIndex;
+}
+
+int UTF8Length(std::string str)
+{
+	const char* tmp = str.c_str();
+	int len = 0;
+	while (*tmp) len += (*tmp++ & 0xc0) != 0x80;
+	
+	return len;
 }

--- a/Core.h
+++ b/Core.h
@@ -11,3 +11,5 @@ void Print(const char * szFormat, ...);
 void __fastcall Say(const char* szMessage);
 bool ClickMap(DWORD dwClickType, int wX, int wY, BOOL bShift, UnitAny* pUnit);
 void LoadMPQ(const char* mpq);
+int UTF8FindByteIndex(std::string str, int maxutf8len);
+int UTF8Length(std::string str);

--- a/D2BS.cpp
+++ b/D2BS.cpp
@@ -46,24 +46,24 @@ BOOL WINAPI DllMain(HINSTANCE hDll, DWORD dwReason, LPVOID lpReserved)
 			Vars.bLoadedWithCGuard = FALSE;
 		}
 
-		ParseCommandLine(GetCommandLineA());
+		ParseCommandLine(GetCommandLineW());
 
-		sLine* command = GetCommand("-title");
+		sLine* command = GetCommand(L"-title");
 
 		if (command)
 		{
-			int len = strlen((char*)command->szText);
-			strncat_s(Vars.szTitle, (char*)command->szText, len);
+			int len = wcslen((wchar_t*)command->szText);
+			wcsncat_s(Vars.szTitle, (wchar_t*)command->szText, len);
 		}
 
-		command = GetCommand("-sleepy");
+		command = GetCommand(L"-sleepy");
 
 		if (command)
 		{
 			Vars.bSleepy = 1;
 		}
 
-		command = GetCommand("-cachefix");
+		command = GetCommand(L"-cachefix");
 
 		if (command)
 		{
@@ -71,64 +71,64 @@ BOOL WINAPI DllMain(HINSTANCE hDll, DWORD dwReason, LPVOID lpReserved)
 		}
 
 
-		command = GetCommand("-multi");
+		command = GetCommand(L"-multi");
 
 		if (command)
 		{
 			Vars.bMulti = TRUE;
 		}
 
-		command = GetCommand("-c0");
+		command = GetCommand(L"-c0");
 
 		if(command) 
 		{
 			Vars.bUseRawCDKey = 1; 
-			const char *keys = (char*)command->szText;
+			const char *keys = UnicodeToAnsi(command->szText);
 			int len = strlen(keys); 
 			strncat_s(Vars.szClassic, keys, len);
 		}
 
-		command = GetCommand("-c1");
+		command = GetCommand(L"-c1");
 
 		if(command) 
 		{
-			const char *keys = (char*)command->szText;
+			const char *keys = UnicodeToAnsi(command->szText);
 			int len = strlen(keys); 
 			strncat_s(Vars.szClassic, keys, len);
 		}
 
-		command = GetCommand("-c2");
+		command = GetCommand(L"-c2");
 
 		if(command) 
 		{
-			const char *keys = (char*)command->szText;
+			const char *keys = UnicodeToAnsi(command->szText);
 			int len = strlen(keys); 
 			strncat_s(Vars.szClassic, keys, len);
 		}
 
-		command = GetCommand("-e0");
+		command = GetCommand(L"-e0");
 
 		if(command) 
 		{
-			const char *keys = (char*)command->szText;
+			const char *keys = UnicodeToAnsi(command->szText);
 			int len = strlen(keys); 
 			strncat_s(Vars.szLod, keys, len);
 		}
 
-		command = GetCommand("-e1");
+		command = GetCommand(L"-e1");
 
 		if(command) 
 		{
-			const char *keys = (char*)command->szText;
+			const char *keys = UnicodeToAnsi(command->szText);
 			int len = strlen(keys); 
 			strncat_s(Vars.szLod, keys, len);
 		}
 
-		command = GetCommand("-e2");
+		command = GetCommand(L"-e2");
 
 		if(command) 
 		{
-			const char *keys = (char*)command->szText;
+			const char *keys = UnicodeToAnsi(command->szText);
 			int len = strlen(keys); 
 			strncat_s(Vars.szLod, keys, len);
 		}

--- a/D2BS.h
+++ b/D2BS.h
@@ -79,7 +79,7 @@ struct Variables
 	char	szDefault[_MAX_FNAME];
 	char	szClassic[30];
 	char	szLod[30];
-	char	szTitle[128];
+	wchar_t	szTitle[256];
 
 	WNDPROC oldWNDPROC;
 	HHOOK hMouseHook;

--- a/D2Handlers.cpp
+++ b/D2Handlers.cpp
@@ -31,41 +31,41 @@ DWORD WINAPI D2Thread(LPVOID lpParam)
 	if(InitHooks())
 	{
 		Log("D2BS Engine startup complete. %s", D2BS_VERSION);
-		Print("ÿc2D2BSÿc0 :: Engine startup complete!");
+		Print("Ã¿c2D2BSÃ¿c0 :: Engine startup complete!");
 	}
 	else
 	{
 		Log("D2BS Engine startup failed.");
-		Print("ÿc2D2BSÿc0 :: Engine startup failed!");
+		Print("Ã¿c2D2BSÃ¿c0 :: Engine startup failed!");
 		return FALSE;
 	}
 
-	ParseCommandLine(GetCommandLineA());
+	ParseCommandLine(GetCommandLineW());
 
-	command = GetCommand("-handle");
+	command = GetCommand(L"-handle");
 
 	if(command) 
 	{
-		Vars.hHandle = (HWND)atoi(command->szText); 
+		Vars.hHandle = (HWND)_wtoi(command->szText); 
 	}
 
-	command = GetCommand("-mpq");
+	command = GetCommand(L"-mpq");
 
 	if(command) 
 	{
-		LoadMPQ(command->szText); 
+		LoadMPQ(UnicodeToAnsi(command->szText)); 
 	}
 
-	command = GetCommand("-profile");
+	command = GetCommand(L"-profile");
 
 	if(command) 
 	{
-		const char* profile = (char*)command->szText;
+		const char* profile = UnicodeToAnsi(command->szText);
 
 		if(SwitchToProfile(profile))
-			Print("ÿc2D2BSÿc0 :: Switched to profile %s", profile);
+			Print("Ã¿c2D2BSÃ¿c0 :: Switched to profile %s", profile);
 		else
-			Print("ÿc2D2BSÿc0 :: Profile %s not found", profile);
+			Print("Ã¿c2D2BSÃ¿c0 :: Profile %s not found", profile);
 	}
 
 	while(Vars.bActive)
@@ -220,9 +220,9 @@ LONG WINAPI GameEventHandler(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 				{
 					const char* profile = (char*)pCopy->lpData;
 					if(SwitchToProfile(profile))
-						Print("ÿc2D2BSÿc0 :: Switched to profile %s", profile);
+						Print("Ã¿c2D2BSÃ¿c0 :: Switched to profile %s", profile);
 					else
-						Print("ÿc2D2BSÿc0 :: Profile %s not found", profile);
+						Print("Ã¿c2D2BSÃ¿c0 :: Profile %s not found", profile);
 				}
 				else if(pCopy->dwData == 0xDEAD)
 				{	

--- a/D2Helpers.cpp
+++ b/D2Helpers.cpp
@@ -1,4 +1,4 @@
-﻿#include <io.h>
+#include <io.h>
 #include <errno.h>
 #include <ctime>
 #include <cmath>
@@ -63,7 +63,7 @@ const char* GetUnitName(UnitAny* pUnit, char* szTmp, size_t bufSize)
 	}
 	if(pUnit->dwType == UNIT_MONSTER) {
 		wchar_t* wName = D2CLIENT_GetUnitName(pUnit);
-		WideCharToMultiByte(CP_ACP, 0, wName, -1, szTmp, bufSize, 0, 0);
+		WideCharToMultiByte(CP_UTF8, 0, wName, -1, szTmp, bufSize, 0, 0);
 		return szTmp;
 	}
 	if(pUnit->dwType == UNIT_PLAYER && pUnit->pPlayerData)
@@ -399,25 +399,13 @@ void AutomapToScreen(POINT* pPos)
 
 void myDrawText(const char* szwText, int x, int y, int color, int font) 
 {
-	size_t found;
 	wchar_t* text = AnsiToUnicode(szwText);
-	std::string temp(szwText);
-	found=temp.find_first_of(-1);
-  
-	while (found!=std::string::npos)
-    {
-       text[found] = 0xff;
-       found=temp.find_first_of(-1,found+1);
-    }
-	
-
 	DWORD dwOld = D2WIN_SetTextSize(font);
 	D2WIN_DrawText(text, x, y, color, 0);
 	D2WIN_SetTextSize(dwOld);
 
 	delete[] text;
 }
-
 
 void myDrawCenterText(const char* szText, int x, int y, int color, int font, int div) 
 {

--- a/D2Intercepts.cpp
+++ b/D2Intercepts.cpp
@@ -355,12 +355,12 @@ HMODULE __stdcall Multi(LPSTR Class, LPSTR Window) { return 0; }
 
 HANDLE __stdcall Windowname(DWORD dwExStyle, LPCSTR lpClassName, LPCSTR lpWindowName, DWORD dwStyle, int x, int y, int nWidth, int nHeight, HWND hWndParent, HMENU hMenu, HINSTANCE hInstance, LPVOID lpParam)
 {
-	CHAR szWindowName[100] = "D2";
+	WCHAR szWindowName[200] = L"D2";
 
-		if (strlen(Vars.szTitle) > 1)
-			strcpy_s(szWindowName, sizeof(szWindowName), Vars.szTitle);
+	if (wcslen(Vars.szTitle) > 1)
+		wcscpy_s(szWindowName, sizeof(szWindowName), Vars.szTitle);
 
-	return CreateWindowExA(dwExStyle, lpClassName, szWindowName, dwStyle, x, y, nWidth, nHeight, hWndParent, hMenu, hInstance, lpParam);
+	return CreateWindowExW(dwExStyle, AnsiToUnicode(lpClassName), szWindowName, dwStyle, x, y, nWidth, nHeight, hWndParent, hMenu, hInstance, lpParam);
 }
 
 HANDLE __stdcall CacheFix(LPCSTR lpFileName, DWORD dwDesiredAccess, DWORD dwShareMode, LPSECURITY_ATTRIBUTES lpSecurityAttributes, DWORD dwCreationDisposition, DWORD dwFlagsAndAttributes, HANDLE hTemplateFile)

--- a/Helpers.cpp
+++ b/Helpers.cpp
@@ -10,21 +10,21 @@
 #include "DbgHelp.h"
 #include "Profile.h"
 
-wchar_t* AnsiToUnicode(const char* str)
+wchar_t* AnsiToUnicode(const char* str, UINT codepage)
 {
 	wchar_t* buf = NULL;
-	int len = MultiByteToWideChar(1252, 0, str, -1, buf, 0);
+	int len = MultiByteToWideChar(codepage, 0, str, -1, buf, 0);
 	buf = new wchar_t[len];
-	MultiByteToWideChar(1252, 0, str, -1, buf, len);
+	MultiByteToWideChar(codepage, 0, str, -1, buf, len);
 	return buf;
 }
 
-char* UnicodeToAnsi(const wchar_t* str)
+char* UnicodeToAnsi(const wchar_t* str, UINT codepage)
 {
 	char* buf = NULL;
-	int len = WideCharToMultiByte(1252, 0, str, -1, buf, 0, "?", NULL);
+	int len = WideCharToMultiByte(codepage, 0, str, -1, buf, 0, (codepage ? NULL : "?"), NULL);
 	buf = new char[len];
-	WideCharToMultiByte(1252, 0, str, -1, buf, len, "?", NULL);
+	WideCharToMultiByte(codepage, 0, str, -1, buf, len, (codepage ? NULL : "?"), NULL);
 	return buf;
 }
 
@@ -210,11 +210,11 @@ void Reload(void)
 {
 	
 	if(ScriptEngine::GetCount() > 0)
-		Print("ÿc2D2BSÿc0 :: Stopping all scripts");
+		Print("Ã¿c2D2BSÃ¿c0 :: Stopping all scripts");
 	ScriptEngine::StopAll();
 
 	if(Vars.bDisableCache != TRUE)
-		Print("ÿc2D2BSÿc0 :: Flushing the script cache");
+		Print("Ã¿c2D2BSÃ¿c0 :: Flushing the script cache");
 	ScriptEngine::FlushCache();
 
 	// wait for things to catch up
@@ -224,9 +224,9 @@ void Reload(void)
 	{
 		const char* script = GetStarterScriptName();
 		if(StartScript(script, GetStarterScriptState()))
-			Print("ÿc2D2BSÿc0 :: Started %s", script);
+			Print("Ã¿c2D2BSÃ¿c0 :: Started %s", script);
 		else
-			Print("ÿc2D2BSÿc0 :: Failed to start %s", script);
+			Print("Ã¿c2D2BSÃ¿c0 :: Failed to start %s", script);
 	}
 }
 
@@ -245,22 +245,22 @@ bool ProcessCommand(const char* command, bool unprocessedIsCommand)
 	{
 		const char* script = GetStarterScriptName();
 		if(StartScript(script, GetStarterScriptState()))
-			Print("ÿc2D2BSÿc0 :: Started %s", script);
+			Print("Ã¿c2D2BSÃ¿c0 :: Started %s", script);
 		else
-			Print("ÿc2D2BSÿc0 :: Failed to start %s", script);
+			Print("Ã¿c2D2BSÃ¿c0 :: Failed to start %s", script);
 		result = true;
 	}
 	else if(_strcmpi(argv, "stop") == 0)
 	{
 		if(ScriptEngine::GetCount() > 0)
-			Print("ÿc2D2BSÿc0 :: Stopping all scripts");
+			Print("Ã¿c2D2BSÃ¿c0 :: Stopping all scripts");
 		ScriptEngine::StopAll();
 		result = true;
 	}
 	else if(_strcmpi(argv, "flush") == 0)
 	{
 		if(Vars.bDisableCache != TRUE)
-			Print("ÿc2D2BSÿc0 :: Flushing the script cache");
+			Print("Ã¿c2D2BSÃ¿c0 :: Flushing the script cache");
 		ScriptEngine::FlushCache();
 		result = true;
 	}
@@ -268,9 +268,9 @@ bool ProcessCommand(const char* command, bool unprocessedIsCommand)
 	{
 		const char* script = command+5;
 		if(StartScript(script, GetStarterScriptState()))
-			Print("ÿc2D2BSÿc0 :: Started %s", script);
+			Print("Ã¿c2D2BSÃ¿c0 :: Started %s", script);
 		else
-			Print("ÿc2D2BSÿc0 :: Failed to start %s", script);
+			Print("Ã¿c2D2BSÃ¿c0 :: Failed to start %s", script);
 		result = true;
 	}
 	else if(_strcmpi(argv, "reload") == 0)
@@ -289,9 +289,9 @@ bool ProcessCommand(const char* command, bool unprocessedIsCommand)
 	{
 		const char* profile = command+8;
 		if(SwitchToProfile(profile))
-			Print("ÿc2D2BSÿc0 :: Switched to profile %s", profile);
+			Print("Ã¿c2D2BSÃ¿c0 :: Switched to profile %s", profile);
 		else
-			Print("ÿc2D2BSÿc0 :: Profile %s not found", profile);
+			Print("Ã¿c2D2BSÃ¿c0 :: Profile %s not found", profile);
 		result = true;
 	}
 #endif
@@ -316,11 +316,11 @@ void GameJoined(void)
 		const char* starter = GetStarterScriptName();
 		if(starter != NULL)
 		{
-			Print("ÿc2D2BSÿc0 :: Starting %s", starter);
+			Print("Ã¿c2D2BSÃ¿c0 :: Starting %s", starter);
 			if(StartScript(starter, GetStarterScriptState()))
-				Print("ÿc2D2BSÿc0 :: %s running.", starter);
+				Print("Ã¿c2D2BSÃ¿c0 :: %s running.", starter);
 			else
-				Print("ÿc2D2BSÿc0 :: Failed to start %s!", starter);
+				Print("Ã¿c2D2BSÃ¿c0 :: Failed to start %s!", starter);
 		}
 	}
 }
@@ -332,11 +332,11 @@ void MenuEntered(bool beginStarter)
 		const char* starter = GetStarterScriptName();
 		if(starter != NULL)
 		{
-			Print("ÿc2D2BSÿc0 :: Starting %s", starter);
+			Print("Ã¿c2D2BSÃ¿c0 :: Starting %s", starter);
 			if(StartScript(starter, GetStarterScriptState()))
-				Print("ÿc2D2BSÿc0 :: %s running.", starter);
+				Print("Ã¿c2D2BSÃ¿c0 :: %s running.", starter);
 			else
-				Print("ÿc2D2BSÿc0 :: Failed to start %s!", starter);
+				Print("Ã¿c2D2BSÃ¿c0 :: Failed to start %s!", starter);
 		}
 	}
 }

--- a/Helpers.h
+++ b/Helpers.h
@@ -5,8 +5,8 @@
 
 #include "Script.h"
 
-wchar_t* AnsiToUnicode(const char* str);
-char* UnicodeToAnsi(const wchar_t* str);
+wchar_t* AnsiToUnicode(const char* str, UINT codepage = CP_UTF8);
+char* UnicodeToAnsi(const wchar_t* str, UINT codepage = CP_UTF8);
 void StringToLower(char* p);
 bool StringToBool(const char* str);
 void StringReplace(char* str, const char find, const char replace, size_t buflen);

--- a/JSCore.cpp
+++ b/JSCore.cpp
@@ -310,7 +310,7 @@ JSAPI_FUNC(my_version)
 		return JS_TRUE;
 	}
 
-	Print("ÿc4D2BSÿc1 ÿc3%s for Diablo II 1.14d.", D2BS_VERSION); 
+	Print("Ã¿c4D2BSÃ¿c1 Ã¿c3%s for Diablo II 1.14d.", D2BS_VERSION); 
 
 	return JS_TRUE;
 }

--- a/JSUnit.cpp
+++ b/JSUnit.cpp
@@ -144,9 +144,9 @@ JSAPI_PROP(unit_getProperty)
 			vp.setInt32(D2GFX_GetScreenSize());
 			break;
 		case OOG_WINDOWTITLE:
-			char szTitle[128];
-			GetWindowText(D2GFX_GetHwnd(), szTitle, 128);
-			vp.setString(JS_NewStringCopyZ(cx, szTitle));
+			wchar_t szTitle[256];
+			GetWindowTextW(D2GFX_GetHwnd(), szTitle, 256);
+			vp.setString(JS_NewStringCopyZ(cx, UnicodeToAnsi(szTitle)));
 			break;
 		case ME_PING:
 			vp.setInt32(*p_D2CLIENT_Ping);
@@ -1844,10 +1844,15 @@ JSAPI_FUNC(my_overhead)
 		char *lpszText = JS_EncodeString(cx,JS_ValueToString(cx, JS_ARGV(cx, vp)[0]));
 		if(lpszText && lpszText[0])
 		{
-			OverheadMsg* pMsg = D2COMMON_GenerateOverheadMsg(NULL, lpszText, *p_D2CLIENT_OverheadTrigger);
+			// Fix overhead msg for locale text
+			wchar_t* tmpw = AnsiToUnicode(lpszText);
+			// Convert back to multibyte in locale code page
+			char* tmpc = UnicodeToAnsi(tmpw, CP_ACP);
+
+			OverheadMsg* pMsg = D2COMMON_GenerateOverheadMsg(NULL, tmpc, *p_D2CLIENT_OverheadTrigger);
 			if(pMsg)
 			{
-				D2COMMON_FixOverheadMsg(pMsg, NULL);
+				//D2COMMON_FixOverheadMsg(pMsg, NULL);
 				pUnit->pOMsg = pMsg;
 			}
 		}

--- a/Map/Diablo_II/LevelMap.cpp
+++ b/Map/Diablo_II/LevelMap.cpp
@@ -505,12 +505,12 @@ void LevelMap::FindRoomLinkageExits(ExitArray& exits, RoomList& added) const
 	
 			if (overlappingX < 0 || overlappingY < 0)
 			{
-				// Print("ÿc1d2bsÿc3LevelMap::GetExitsÿc0 adjecent room is out of reach - it's not even touching local room in corner!");
+				// Print("Ã¿c1d2bsÃ¿c3LevelMap::GetExitsÃ¿c0 adjecent room is out of reach - it's not even touching local room in corner!");
 				continue;
 			}
 			if (overlappingX > 0 && overlappingY > 0)
 			{
-				// Print("ÿc1d2bsÿc3LevelMap::GetExitsÿc0 WTF local and adjecent rooms are overlapping (they share some points)!!!");
+				// Print("Ã¿c1d2bsÃ¿c3LevelMap::GetExitsÃ¿c0 WTF local and adjecent rooms are overlapping (they share some points)!!!");
 				continue;             
 			}
 			if (overlappingX < 3 && overlappingY < 3)

--- a/Script.cpp
+++ b/Script.cpp
@@ -166,7 +166,7 @@ void Script::Run(void)
 		}
 
 		if(scriptState == Command){			
-			char * cmd = "function main() {print('ÿc2D2BSÿc0 :: Started Console'); while (true){delay(10000)};}  ";
+			char * cmd = "function main() {print('Ã¿c2D2BSÃ¿c0 :: Started Console'); while (true){delay(10000)};}  ";
 			script = JS_CompileScript(context, globalObject, cmd, strlen(cmd), "Command Line", 1);
 			JS_AddNamedScriptRoot(context, &script, "console script");
 		}

--- a/ScriptEngine.cpp
+++ b/ScriptEngine.cpp
@@ -488,7 +488,7 @@ void reportError(JSContext *cx, const char *message, JSErrorReport *report)
 	Log("[%s%s] Code(%d) File(%s:%d) %s\nLine: %s", 
 			strict, type, report->errorNumber, filename, report->lineno, message, report->linebuf);
 
-	Print("[ÿc%d%s%sÿc0 (%d)] File(%s:%d) %s", 
+	Print("[Ã¿c%d%s%sÃ¿c0 (%d)] File(%s:%d) %s", 
 			(warn ? 9 : 1), strict, type, report->errorNumber, displayName, report->lineno, message);
 
 	free(filename);


### PR DESCRIPTION
Converted all source files containing unicode characters to utf-8 encoding.

Changed to use utf-8 conversion between widechars and multibytechars and vice versa
(removed old hotfix for color encoding since it's no longer necessary)

Fixed overhead message and window title to allow unicode characters (temp fix, colors won't work)

Changed line split length to account for utf-8 strings when printing

Changed command line parsing to use widechars